### PR TITLE
feat: [1.0.1]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # use-sync-query-params
 
-> Sync React props/states to URL query params. Zero dependency.
+> Sync React props/states to URL query params.
 
 ## Purposes
 
-- Initialize the URL query params with a default ones.
+- Initialize the URL query params with default ones.
   - The default params can come from any source: `redux`, `props`, computed variables...
 - Update query params on demand
 
@@ -29,7 +29,7 @@ export default function App(props) {
       <br/>
       <button onClick={() => params.setParam('foo', 'baz')}>Change bar to baz</button>
       <br/>
-      <button onClick={() => params.setParam('foo', null)}>Clear query param<button>
+      <button onClick={() => params.clearParam('foo')}>Clear query param<button>
     </>
   )
 }
@@ -37,7 +37,7 @@ export default function App(props) {
 
 ## APIs
 
-1. `useSyncQueryParams(defaultParams: { [x: string]: string | number | boolean | null | undefined }) => ({ getParam, getAllParams, setParam })`
+1. `useSyncQueryParams(defaultParams: { [x: string]: string | number | boolean | null | undefined }) => ({ getParam, getAllParams, setParam, clearParam })`
 
    Initial the hook with default params. Automatic URL query params synchronization will happen only once on mount.
 
@@ -51,6 +51,13 @@ export default function App(props) {
 
    Get all query params. The result contains all records with keys of the default params except those that were cleared.
 
-4. `setParam: (key: string, value: string | number | boolean | null | undefined) => void`
+4. `setParam: (key: string, value: string | number | boolean | null | undefined) => boolean`
 
    Set a specific key with a value. Empty values (empty string, null, undefined) will be cleared.
+
+   - Return `true` if successfully set
+   - Otherwise `false` if `window.history.pushState` is not available
+
+5. `clearParam: (key: string) => void`
+
+   Clear specific key from query params. Same as `setParam` with empty value.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
@@ -75,5 +75,8 @@
   "bugs": {
     "url": "https://github.com/duyth1203/use-sync-query-params/issues"
   },
-  "homepage": "https://github.com/duyth1203/use-sync-query-params#readme"
+  "homepage": "https://github.com/duyth1203/use-sync-query-params#readme",
+  "dependencies": {
+    "url-search-params-polyfill": "^8.1.1"
+  }
 }

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -3,28 +3,41 @@ import { act, renderHook } from '@testing-library/react';
 import useSyncQueryParams from '../src';
 
 describe('Test custom hook `useSyncQueryParams`', () => {
+  beforeEach(() => {
+    // Reset query params to empty
+    const path = window.location.origin + window.location.pathname;
+    window.history.pushState({ path }, '', path);
+  });
+
   it('should not show any query param on mount with no default params', () => {
     const { result } = renderHook(() => useSyncQueryParams({}));
+
     expect(window.location.search).toBe('');
     expect(result.current.getAllParams()).toMatchObject({});
   });
 
-  it('should properly set query param', () => {
+  it('should properly sync query param on mount', () => {
     const { result } = renderHook(() => useSyncQueryParams({ foo: 'bar' }));
 
     expect(window.location.search).toBe('?foo=bar');
     expect(result.current.getParam('foo')).toBe('bar');
   });
 
-  it('should parse query `string` properly', () => {
+  it('should parse query properly', () => {
+    let setterResult: boolean = false;
+    const path = window.location.origin + window.location.pathname + '?foo=baz';
+    window.history.pushState({ path }, '', path);
     const { result } = renderHook(() => useSyncQueryParams({ foo: 'bar' }));
 
+    expect(window.location.search).toBe('?foo=baz');
+
     act(() => {
-      result.current.setParam('foo', 'baz');
+      setterResult = result.current.setParam('foo', 'baz2');
     });
 
-    expect(window.location.search).toBe('?foo=baz');
-    expect(result.current.getParam('foo')).toBe('baz');
+    expect(setterResult).toBeTruthy();
+    expect(window.location.search).toBe('?foo=baz2');
+    expect(result.current.getParam('foo')).toBe('baz2');
   });
 
   it('should parse query empty `string` properly', () => {
@@ -56,6 +69,42 @@ describe('Test custom hook `useSyncQueryParams`', () => {
       result.current.setParam('foo', undefined);
     });
 
+    expect(window.location.search).toBe('');
+    expect(result.current.getParam('foo')).toBeUndefined();
+  });
+
+  it('should clear query param properly', () => {
+    const { result } = renderHook(() => useSyncQueryParams({ foo: 'bar' }));
+
+    act(() => {
+      result.current.clearParam('foo');
+    });
+
+    expect(window.location.search).toBe('');
+    expect(result.current.getParam('foo')).toBeUndefined();
+  });
+
+  it('should not sync default param with empty value to URL query params', () => {
+    const { result } = renderHook(() =>
+      useSyncQueryParams({ foo: undefined, foo2: 'bar' })
+    );
+
+    expect(window.location.search).toBe('?foo2=bar');
+    expect(result.current.getParam('foo2')).toBe('bar');
+    expect(result.current.getParam('foo')).toBeUndefined();
+  });
+
+  it('should not sync both hook states and URL query params when `window.history.pushState` is not available', () => {
+    let setterResult: boolean = true;
+    // @ts-ignore
+    window.history.pushState = undefined;
+    const { result } = renderHook(() => useSyncQueryParams({ foo: undefined }));
+
+    act(() => {
+      setterResult = result.current.setParam('foo', 'baz');
+    });
+
+    expect(setterResult).toBeFalsy();
     expect(window.location.search).toBe('');
     expect(result.current.getParam('foo')).toBeUndefined();
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6525,6 +6525,11 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==
 
+url-search-params-polyfill@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-8.1.1.tgz#9e69e4dba300a71ae7ad3cead62c7717fd99329f"
+  integrity sha512-KmkCs6SjE6t4ihrfW9JelAPQIIIFbJweaaSLTh/4AO+c58JlDcb+GbdPt8yr5lRcFg4rPswRFRRhBGpWwh0K/Q==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"


### PR DESCRIPTION
- add `URLSearchParams` polyfill to support IE11
- add new function `clearParam`
- update tests
- fix README typos
- fix an issue where the hook not uses default when URL query empty